### PR TITLE
Add object directory as prerequisite

### DIFF
--- a/templates/makefile.txt
+++ b/templates/makefile.txt
@@ -26,6 +26,11 @@ OBJECTS = $(addprefix $(OBJ)/, $(addsuffix .o, $(FILENAMES)))
 all: $(OBJECTS)
 	$(CC) -o $(OBJ)/[PROJECT_NAME] $(OBJECTS)
 
+$(OBJECTS): | $(OBJ)/  # "Check" if the build directory exists
+
+$(OBJ)/:  # Create a build (object) directory
+	mkdir -p $@
+
 $(OBJ)/%.o: %.c
 	$(CC) -c $< $(CFLAGS) -o $@
 


### PR DESCRIPTION
Right now, if the build directory does not exist when the makefile is executed the make will fail to compile any object file and the following fatal error will be displayed:
`Fatal error: can't create build/foo.o: No such file or directory`

Adding the build directory as a prerequisite will fix this by creating the build directory when the makefile is run if it doesn't already exist.